### PR TITLE
발표자 뽑는 로직 변경(가중치 할당)

### DIFF
--- a/pick.py
+++ b/pick.py
@@ -1,15 +1,47 @@
 import random
 from datetime import datetime, timedelta
 
+members = ["소병희", "이지민", "장희직", "전현수"]
+weightedMembers = []
+
+
+def findLastPresenters():
+    with open('README.md', 'r') as f:
+        last_line = f.readlines()[-1]
+
+    lastPresentersData = last_line.strip().split("|")
+
+    return [lastPresentersData[2].strip(), lastPresentersData[3].strip()]
+
 
 def getRandomPresenters():
-    members = ["소병희", "이지민", "장희직", "전현수"]
-    random.shuffle(members)
-    return [members[0], members[1]]
+    (lastFirstPresenter, lastSecondPresenter) = findLastPresenters()
+
+    for member in members:
+
+        if member == lastFirstPresenter:
+            weight = 2
+        elif member == lastSecondPresenter:
+            weight = 3
+        else:
+            weight = 5
+
+        for _ in range(weight):
+            weightedMembers.append(member)
+
+    random.shuffle(weightedMembers)
+    firstPresenter = weightedMembers[0]
+
+    filteredWeightedMembers = list(filter(lambda presenter: presenter != firstPresenter, weightedMembers))
+
+    random.shuffle(filteredWeightedMembers)
+    secondPresenter = filteredWeightedMembers[0]
+
+    return [firstPresenter, secondPresenter]
 
 
 presenters = getRandomPresenters()
-
+print(weightedMembers)
 result = (datetime.today() + timedelta(days=1)).strftime("| %Y년 %m년 %d일 | {}      | {}      |").format(presenters[0],
                                                                                                        presenters[1])
 file = open("README.md", 'a')


### PR DESCRIPTION
## 개요
- 지민님만 너무 발표를 많이하시는 것 같아 발표자 선정 로직을 살짝 변경해봤습니다..

## 로직 설명

### 이전 로직
- 그냥 멤버 이름 하나씩 리스트에 넣고, shuffle 후 
- `0번째 인덱스 == 첫 번째 발표자`, `1번째 인덱스 == 두 번째 발표자`

### 변경된 로직
- 가중치를 할당
  - 이전 주차에 첫 번째로 발표했다면 2, 두 번째로 발표했다면 3, 발표를 하지 않았다면 5
- 가중치만큼 리스트에 삽입
  - ex) 지민님이 지난 주에 첫 번째로 발표를 했다면 리스트에 "이지민" 두 개 삽입
  - ex) 병희님이 지난 주에 발표를 하지 않았다면 리스트에 "소병희" 다섯 개 삽입
- shuffle 후 `0번째 인덱스 == 첫 번째 발표자`
- 첫 번째 발표자를 리스트에서 제외(필터링)
- 다시 shuffle 후 `0번째 인덱스 == 두 번째 발표자`